### PR TITLE
Updated error handling on inaccessible servers.

### DIFF
--- a/pkg/shortscan/shortscan.go
+++ b/pkg/shortscan/shortscan.go
@@ -804,7 +804,8 @@ func Scan(urls []string, hc *http.Client, st *httpStats, wc wordlistConfig, mk m
 		// Grab some headers and make sure the URL is accessible
 		res, err := fetch(hc, st, "GET", url+".aspx")
 		if err != nil {
-			log.WithFields(log.Fields{"error": err}).Fatal("Unable to access server")
+			fmt.Printf("Unable to access server: %s\n", url)
+                        continue
 		}
 
 		// Display server information


### PR DESCRIPTION
Updated error handling when the server is inaccessible. 

If the server is not accessible it will simply print the error and continue rather than throwing a fatal error. This will allow scans that are iterating over multiple servers in a file to continue if an inaccessible server is hit.